### PR TITLE
fix: shows max number in roll number response

### DIFF
--- a/src/__test__/roll-number.test.ts
+++ b/src/__test__/roll-number.test.ts
@@ -1,4 +1,4 @@
-import { toNumber } from 'lodash';
+import { toNumber, split } from 'lodash';
 
 import { handler } from '../roll-number';
 import mockContext from './mock-context';
@@ -12,7 +12,7 @@ describe('roll number', () => {
         expect(err).toBeNull();
         expect(responseUrl).toBe('responseUrl');
         expect(identity).toBe('identity');
-        expect(toNumber(text)).toBeLessThanOrEqual(5);
+        expect(toNumber(split(text, ' ')[0])).toBeLessThanOrEqual(5);
         done();
       }
     );

--- a/src/roll-number.ts
+++ b/src/roll-number.ts
@@ -3,7 +3,7 @@ import { Callback, Context } from 'aws-lambda';
 import State from './state';
 
 export const handler = (event: State, context: Context, callback: Callback): void => {
-  const { identity, responseUrl, number: max = 1 } = event;
-  const text = `${Math.floor(Math.random() * max + 1)}`;
+  const { identity, responseUrl, number: max = 100 } = event;
+  const text = `${Math.floor(Math.random() * max + 1)} (${max})`;
   callback(null, { text, identity, responseUrl });
 };


### PR DESCRIPTION
Show the result as `@xxx just rolled: 2 (99)`